### PR TITLE
Updated pricing information

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This library uses:
 - **Text-to-Speech Engines**
   - **OpenAIEngine**: OpenAI's TTS system offers 6 natural sounding voices.
   - **CoquiEngine**: High quality local neural TTS.
-  - **AzureEngine**: Microsoft's leading TTS technology. 250000 chars free per month.
+  - **AzureEngine**: Microsoft's leading TTS technology. 500000 chars free per month.
   - **ElevenlabsEngine**: Offer the best sounding voices available.
   - **SystemEngine**: Native engine for quick setup.
 


### PR DESCRIPTION
# Simple change on AzureEngine pricing in README.md

250000 -> 500000 

Love this project, was checking out [pricing options for azure](https://azure.microsoft.com/en-gb/pricing/details/cognitive-services/speech-services/) and noticed there was **more free chars** than shown here! Pleasant surprise. 

![image](https://github.com/k0hacuu/RealtimeTTS/assets/66693748/bfa564ab-8388-4ba5-8eec-c1cf28185061)
