### PR TITLE
Daemonize coqui engine output_worker

### DIFF
--- a/RealtimeTTS/engines/coqui_engine.py
+++ b/RealtimeTTS/engines/coqui_engine.py
@@ -208,6 +208,7 @@ class CoquiEngine(BaseEngine):
         self.output_worker_thread = Thread(
             target=output_worker,
             args=(self.output_queue,))
+        self.output_worker_thread.daemon = True
         self.output_worker_thread.start()
 
         self.main_synthesize_ready_event = mp.Event()


### PR DESCRIPTION
Daemonize the output worker thread so it exits with main thread.

Hey, I've been using this project and have been loving it so far. I noticed that the output worker thread wasn't daemonized, so it was preventing my program from exiting even after closing all my threads. It seemed to work perfectly fine with this change, but if this was a conscious decision, feel free to reject.