### PR TITLE
Fix: typo in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,11 +15,6 @@ gtts==2.5.3
 
 # coqui_tts is for CoquiEngine
 coqui_tts==0.24.2
-<<<<<<< HEAD
-
-
-=======
->>>>>>> 4365a99e1a1e7b1705a201d5032677676aade239
 
 # stream2sentence is to quickly convert streamed text into sentences for real-time synthesis
 stream2sentence==0.2.5


### PR DESCRIPTION
Removes merge conflict markers
Specifies the coqui_tts version as 0.24.2
Cleans up file formatting

Before:
```
<<<<<<< HEAD

=======
>>>>>>> 4365a99e1a1e7b1705a201d5032677676aade239
# stream2sentence is to quickly convert streamed text into sentences for real-time synthesis
stream2sentence==0.2.5
After:
coqui_tts==0.24.2
```

After:
```
# stream2sentence is to quickly convert streamed text into sentences for real-time synthesis
stream2sentence==0.2.5
```
