### PR TITLE
Add: Spanish docs

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -1,6 +1,6 @@
 # RealtimeTTS
 
-[EN](../en/index.md) | [FR](../fr/index.md)
+[EN](../en/index.md) | [FR](../fr/index.md) | [ES](../es/index.md)
 
 *Easy to use, low-latency text-to-speech library for realtime applications*
 

--- a/docs/es/api.md
+++ b/docs/es/api.md
@@ -1,0 +1,181 @@
+# TextToAudioStream - Documentación en Español
+
+## Configuración
+
+### Parámetros de Inicialización para `TextToAudioStream`
+
+Cuando inicializa la clase `TextToAudioStream`, tiene varias opciones para personalizar su comportamiento. Aquí están los parámetros disponibles:
+
+### Parámetros Principales
+
+#### `engine` (BaseEngine)
+* **Tipo**: BaseEngine
+* **Requerido**: Sí
+* **Descripción**: El motor subyacente responsable de la síntesis de texto a audio. Debe proporcionar una instancia de `BaseEngine` o su subclase para habilitar la síntesis de audio.
+
+#### `on_text_stream_start` (callable)
+* **Tipo**: Función callable
+* **Requerido**: No
+* **Descripción**: Esta función de callback opcional se activa cuando comienza el flujo de texto. Utilícela para cualquier configuración o registro que pueda necesitar.
+
+#### `on_text_stream_stop` (callable)
+* **Tipo**: Función callable
+* **Requerido**: No
+* **Descripción**: Esta función de callback opcional se activa cuando finaliza el flujo de texto. Puede utilizarla para tareas de limpieza o registro.
+
+#### `on_audio_stream_start` (callable)
+* **Tipo**: Función callable
+* **Requerido**: No
+* **Descripción**: Esta función de callback opcional se invoca cuando comienza el flujo de audio. Útil para actualizaciones de UI o registro de eventos.
+
+#### `on_audio_stream_stop` (callable)
+* **Tipo**: Función callable
+* **Requerido**: No
+* **Descripción**: Esta función de callback opcional se llama cuando se detiene el flujo de audio. Ideal para limpieza de recursos o tareas de post-procesamiento.
+
+#### `on_character` (callable)
+* **Tipo**: Función callable
+* **Requerido**: No
+* **Descripción**: Esta función de callback opcional se llama cuando se procesa un solo carácter.
+
+#### `output_device_index` (int)
+* **Tipo**: Entero
+* **Requerido**: No
+* **Valor predeterminado**: None
+* **Descripción**: Especifica el índice del dispositivo de salida a utilizar. None usa el dispositivo predeterminado.
+
+#### `tokenizer` (string)
+* **Tipo**: String
+* **Requerido**: No
+* **Valor predeterminado**: nltk
+* **Descripción**: Tokenizador a utilizar para la división de oraciones (actualmente se admiten "nltk" y "stanza").
+
+#### `language` (string)
+* **Tipo**: String
+* **Requerido**: No
+* **Valor predeterminado**: en
+* **Descripción**: Idioma a utilizar para la división de oraciones.
+
+#### `muted` (bool)
+* **Tipo**: Bool
+* **Requerido**: No
+* **Valor predeterminado**: False
+* **Descripción**: Parámetro global de silencio. Si es True, no se abrirá ningún flujo pyAudio. Deshabilita la reproducción de audio a través de los altavoces locales.
+
+#### `level` (int)
+* **Tipo**: Entero
+* **Requerido**: No
+* **Valor predeterminado**: `logging.WARNING`
+* **Descripción**: Establece el nivel de registro para el registrador interno. Puede ser cualquier constante entera del módulo `logging` incorporado de Python.
+
+### Ejemplo de Uso
+
+```python
+engine = YourEngine()  # Sustituya con su motor
+stream = TextToAudioStream(
+    engine=engine,
+    on_text_stream_start=my_text_start_func,
+    on_text_stream_stop=my_text_stop_func,
+    on_audio_stream_start=my_audio_start_func,
+    on_audio_stream_stop=my_audio_stop_func,
+    level=logging.INFO
+)
+```
+
+## Métodos
+
+### `play` y `play_async`
+
+Estos métodos son responsables de ejecutar la síntesis de texto a audio y reproducir el flujo de audio. La diferencia es que `play` es una función bloqueante, mientras que `play_async` se ejecuta en un hilo separado, permitiendo que otras operaciones continúen.
+
+### Parámetros de Reproducción
+
+#### `fast_sentence_fragment` (bool)
+* **Valor predeterminado**: `True`
+* **Descripción**: Cuando se establece en `True`, el método priorizará la velocidad, generando y reproduciendo fragmentos de oraciones más rápidamente.
+
+#### `fast_sentence_fragment_allsentences` (bool)
+* **Valor predeterminado**: `False`
+* **Descripción**: Cuando se establece en `True`, aplica el procesamiento rápido de fragmentos de oraciones a todas las oraciones.
+
+#### `fast_sentence_fragment_allsentences_multiple` (bool)
+* **Valor predeterminado**: `False`
+* **Descripción**: Cuando se establece en `True`, permite generar múltiples fragmentos de oraciones.
+
+#### `buffer_threshold_seconds` (float)
+* **Valor predeterminado**: `0.0`
+* **Descripción**: Especifica el tiempo en segundos para el umbral de búfer.
+
+  **Cómo funciona**: Antes de sintetizar una nueva oración, el sistema verifica si queda más material de audio en el búfer que el tiempo especificado. Un valor más alto asegura que haya más audio pre-almacenado en el búfer.
+
+#### `minimum_sentence_length` (int)
+* **Valor predeterminado**: `10`
+* **Descripción**: Establece la longitud mínima de caracteres para considerar una cadena como una oración.
+
+#### `minimum_first_fragment_length` (int)
+* **Valor predeterminado**: `10`
+* **Descripción**: El número mínimo de caracteres requeridos para el primer fragmento de oración.
+
+#### `log_synthesized_text` (bool)
+* **Valor predeterminado**: `False`
+* **Descripción**: Cuando está habilitado, registra los fragmentos de texto sintetizados.
+
+#### `reset_generated_text` (bool)
+* **Valor predeterminado**: `True`
+* **Descripción**: Si es True, reinicia el texto generado antes del procesamiento.
+
+#### `output_wavfile` (str)
+* **Valor predeterminado**: `None`
+* **Descripción**: Si se establece, guarda el audio en el archivo WAV especificado.
+
+#### Funciones de Callback
+
+#### `on_sentence_synthesized` (callable)
+* **Valor predeterminado**: `None`
+* **Descripción**: Se llama después de sintetizar un fragmento de oración.
+
+#### `before_sentence_synthesized` (callable)
+* **Valor predeterminado**: `None`
+* **Descripción**: Se llama antes de sintetizar un fragmento de oración.
+
+#### `on_audio_chunk` (callable)
+* **Valor predeterminado**: `None`
+* **Descripción**: Se llama cuando un fragmento de audio está listo.
+
+### Configuración de Tokenización
+
+#### `tokenizer` (str)
+* **Valor predeterminado**: `"nltk"`
+* **Descripción**: Tokenizador para la división de oraciones. Admite "nltk" y "stanza".
+
+#### `tokenize_sentences` (callable)
+* **Valor predeterminado**: `None`
+* **Descripción**: Función personalizada para tokenizar oraciones del texto de entrada.
+
+#### `language` (str)
+* **Valor predeterminado**: `"en"`
+* **Descripción**: Idioma para la división de oraciones.
+
+### Parámetros de Contexto
+
+#### `context_size` (int)
+* **Valor predeterminado**: `12`
+* **Descripción**: Caracteres utilizados para establecer el contexto de límites de oraciones.
+
+#### `context_size_look_overhead` (int)
+* **Valor predeterminado**: `12`
+* **Descripción**: Tamaño de contexto adicional para mirar hacia adelante.
+
+### Otros Parámetros
+
+#### `muted` (bool)
+* **Valor predeterminado**: `False`
+* **Descripción**: Deshabilita la reproducción de audio local si es True.
+
+#### `sentence_fragment_delimiters` (str)
+* **Valor predeterminado**: `".?!;:,\n…)]}。-"`
+* **Descripción**: Caracteres considerados como delimitadores de oraciones.
+
+#### `force_first_fragment_after_words` (int)
+* **Valor predeterminado**: `15`
+* **Descripción**: Número de palabras después de las cuales se fuerza el primer fragmento.

--- a/docs/es/contributing.md
+++ b/docs/es/contributing.md
@@ -1,0 +1,20 @@
+# Contribuir a RealtimeTTS
+
+Agradecemos cualquier contribución a RealtimeTTS. Aquí tienes algunas formas de contribuir:
+
+1. **Informar de errores**: Si encuentras un error, por favor abre una incidencia en nuestro [repositorio GitHub](https://github.com/KoljaB/RealtimeTTS/issues).
+
+2. **Sugerir mejoras**: ¿Tienes ideas para nuevas funciones o mejoras? Nos encantaría escucharlas. Abre una incidencia para sugerir mejoras.
+
+3. **Contribuciones de código**: ¿Quieres añadir una nueva función o corregir un error? ¡Perfecto! Sigue estos pasos:
+   - Abre el repositorio
+   - Crea una nueva rama para tu función
+   - Realice los cambios
+   - Envía un pull request con una descripción clara de tus cambios
+
+4. **Documentación**: Ayúdanos a mejorar nuestra documentación corrigiendo erratas, añadiendo ejemplos o aclarando secciones confusas.
+
+5. **Añadir nuevos motores**: Si quieres añadir soporte para un nuevo motor TTS, por favor abre una incidencia primero para discutir la implementación.
+
+
+Gracias por ayudarnos a mejorar RealtimeTTS.

--- a/docs/es/faq.md
+++ b/docs/es/faq.md
@@ -1,0 +1,12 @@
+# Preguntas frecuentes
+
+Para obtener respuestas a las preguntas más frecuentes sobre RealtimeTTS, consulta nuestra [página de preguntas frecuentes en GitHub](https://github.com/KoljaB/RealtimeTTS/blob/main/FAQ.md).
+
+Esta página cubre varios temas, entre ellos
+
+- Uso de diferentes motores TTS
+- Tratamiento de textos multilingües
+- Optimización del rendimiento
+- Solución de problemas comunes
+
+Para obtener información más detallada, visite el enlace anterior.

--- a/docs/es/index.md
+++ b/docs/es/index.md
@@ -1,0 +1,19 @@
+# RealtimeTTS
+
+[EN](../en/index.md) | [FR](../fr/index.md) | [ES](../es/index.md)
+
+*Biblioteca de conversión de texto en voz fácil de usar y de baja latencia para aplicaciones en tiempo real.
+
+## Acerca del proyecto
+
+RealtimeTTS es una biblioteca de texto a voz (TTS) de última generación diseñada para aplicaciones en tiempo real. Destaca por su capacidad para convertir rápidamente flujos de texto en salida auditiva de alta calidad con una latencia mínima.
+
+## Características principales
+
+- **Baja latencia**: conversión de texto a voz casi instantánea, compatible con salidas LLM.
+- Audio de alta calidad**: genera un habla clara y natural.
+- Compatible con múltiples motores TTS**: compatible con OpenAI TTS, Elevenlabs, Azure Speech Services, Coqui TTS, gTTS y System TTS
+- Multilingüe
+- Robusto y fiable**: garantiza un funcionamiento continuo gracias a un mecanismo de reserva que cambia a motores alternativos en caso de interrupciones, lo que garantiza un rendimiento y una fiabilidad constantes.
+
+Para obtener instrucciones de instalación, ejemplos de uso y referencias de la API, navegue por la documentación utilizando la barra lateral.

--- a/docs/es/installation.md
+++ b/docs/es/installation.md
@@ -1,0 +1,188 @@
+> **Nota:** Ya no se recomienda la instalación básica con `pip install realtimetts`, use `pip install realtimetts[all]` en su lugar.
+
+La biblioteca RealtimeTTS proporciona opciones de instalación para varias dependencias según su caso de uso. Aquí están las diferentes formas en que puede instalar RealtimeTTS según sus necesidades:
+
+### Instalación Completa
+
+Para instalar RealtimeTTS con soporte para todos los motores de TTS:
+
+```
+pip install -U realtimetts[all]
+```
+
+### Instalación Personalizada
+
+RealtimeTTS permite una instalación personalizada con instalaciones mínimas de bibliotecas. Estas son las opciones disponibles:
+- **all**: Instalación completa con todos los motores soportados.
+- **system**: Incluye capacidades de TTS específicas del sistema (por ejemplo, pyttsx3).
+- **azure**: Agrega soporte para Azure Cognitive Services Speech.
+- **elevenlabs**: Incluye integración con la API de ElevenLabs.
+- **openai**: Para servicios de voz de OpenAI.
+- **gtts**: Soporte para Google Text-to-Speech.
+- **coqui**: Instala el motor Coqui TTS.
+- **minimal**: Instala solo los requisitos base sin motor (solo necesario si desea desarrollar un motor propio)
+
+Por ejemplo, si desea instalar RealtimeTTS solo para uso local de Coqui TTS neuronal, debe usar:
+
+```
+pip install realtimetts[coqui]
+```
+
+Si desea instalar RealtimeTTS solo con Azure Cognitive Services Speech, ElevenLabs y soporte de OpenAI:
+
+```
+pip install realtimetts[azure,elevenlabs,openai]
+```
+
+### Instalación en Entorno Virtual
+
+Para aquellos que deseen realizar una instalación completa dentro de un entorno virtual, sigan estos pasos:
+
+```
+python -m venv env_realtimetts
+env_realtimetts\Scripts\activate.bat
+python.exe -m pip install --upgrade pip
+pip install -U realtimetts[all]
+```
+
+Más información sobre [instalación de CUDA](#instalación-de-cuda).
+
+## Requisitos de los Motores
+
+Los diferentes motores soportados por RealtimeTTS tienen requisitos únicos. Asegúrese de cumplir con estos requisitos según el motor que elija.
+
+### SystemEngine
+El `SystemEngine` funciona de inmediato con las capacidades de TTS incorporadas en su sistema. No se necesita configuración adicional.
+
+### GTTSEngine
+El `GTTSEngine` funciona de inmediato usando la API de texto a voz de Google Translate. No se necesita configuración adicional.
+
+### OpenAIEngine
+Para usar el `OpenAIEngine`:
+- configure la variable de entorno OPENAI_API_KEY
+- instale ffmpeg (ver [instalación de CUDA](#instalación-de-cuda) punto 3)
+
+### AzureEngine
+Para usar el `AzureEngine`, necesitará:
+- Clave API de Microsoft Azure Text-to-Speech (proporcionada a través del parámetro "speech_key" del constructor AzureEngine o en la variable de entorno AZURE_SPEECH_KEY)
+- Región de servicio de Microsoft Azure.
+
+Asegúrese de tener estas credenciales disponibles y correctamente configuradas al inicializar el `AzureEngine`.
+
+### ElevenlabsEngine
+Para el `ElevenlabsEngine`, necesita:
+- Clave API de Elevenlabs (proporcionada a través del parámetro "api_key" del constructor ElevenlabsEngine o en la variable de entorno ELEVENLABS_API_KEY)
+- `mpv` instalado en su sistema (esencial para transmitir audio mpeg, Elevenlabs solo entrega mpeg).
+
+  🔹 **Instalación de `mpv`:**
+  - **macOS**:
+    ```
+    brew install mpv
+    ```
+
+  - **Linux y Windows**: Visite [mpv.io](https://mpv.io/) para instrucciones de instalación.
+
+### CoquiEngine
+
+Proporciona TTS neuronal local de alta calidad con clonación de voz.
+
+Descarga primero un modelo neuronal TTS. En la mayoría de los casos, será lo suficientemente rápido para tiempo real usando síntesis GPU. Necesita alrededor de 4-5 GB de VRAM.
+
+- para clonar una voz, envíe el nombre del archivo de un archivo wave que contenga la voz fuente como parámetro "voice" al constructor CoquiEngine
+- la clonación de voz funciona mejor con un archivo WAV mono de 16 bits a 22050 Hz que contenga una muestra corta (~5-30 seg)
+
+En la mayoría de los sistemas, se necesitará soporte de GPU para ejecutarse lo suficientemente rápido en tiempo real, de lo contrario experimentará tartamudeo.
+
+### Instalación de CUDA
+
+Estos pasos son recomendados para aquellos que requieren **mejor rendimiento** y tienen una GPU NVIDIA compatible.
+
+> **Nota**: *para verificar si su GPU NVIDIA es compatible con CUDA, visite la [lista oficial de GPUs CUDA](https://developer.nvidia.com/cuda-gpus).*
+
+Para usar torch con soporte vía CUDA, siga estos pasos:
+
+> **Nota**: *las instalaciones más nuevas de pytorch [pueden](https://stackoverflow.com/a/77069523) (no verificado) no necesitar la instalación de Toolkit (y posiblemente cuDNN).*
+
+1. **Instalar NVIDIA CUDA Toolkit**:
+    Por ejemplo, para instalar Toolkit 12.X, por favor
+    - Visite [NVIDIA CUDA Downloads](https://developer.nvidia.com/cuda-downloads).
+    - Seleccione su sistema operativo, arquitectura del sistema y versión del sistema operativo.
+    - Descargue e instale el software.
+
+    o para instalar Toolkit 11.8, por favor
+    - Visite [NVIDIA CUDA Toolkit Archive](https://developer.nvidia.com/cuda-11-8-0-download-archive).
+    - Seleccione su sistema operativo, arquitectura del sistema y versión del sistema operativo.
+    - Descargue e instale el software.
+
+2. **Instalar NVIDIA cuDNN**:
+
+    Por ejemplo, para instalar cuDNN 8.7.0 para CUDA 11.x por favor
+    - Visite [NVIDIA cuDNN Archive](https://developer.nvidia.com/rdp/cudnn-archive).
+    - Haga clic en "Download cuDNN v8.7.0 (November 28th, 2022), for CUDA 11.x".
+    - Descargue e instale el software.
+
+3. **Instalar ffmpeg**:
+
+    Puede descargar un instalador para su sistema operativo desde el [sitio web de ffmpeg](https://ffmpeg.org/download.html).
+
+    O usar un gestor de paquetes:
+
+    - **En Ubuntu o Debian**:
+        ```
+        sudo apt update && sudo apt install ffmpeg
+        ```
+
+    - **En Arch Linux**:
+        ```
+        sudo pacman -S ffmpeg
+        ```
+
+    - **En MacOS usando Homebrew** ([https://brew.sh/](https://brew.sh/)):
+        ```
+        brew install ffmpeg
+        ```
+
+    - **En Windows usando Chocolatey** ([https://chocolatey.org/](https://chocolatey.org/)):
+        ```
+        choco install ffmpeg
+        ```
+
+    - **En Windows usando Scoop** ([https://scoop.sh/](https://scoop.sh/)):
+        ```
+        scoop install ffmpeg
+        ```
+
+4. **Instalar PyTorch con soporte CUDA**:
+
+    Para actualizar su instalación de PyTorch y habilitar el soporte de GPU con CUDA, siga estas instrucciones según su versión específica de CUDA. Esto es útil si desea mejorar el rendimiento de RealtimeSTT con capacidades CUDA.
+
+    - **Para CUDA 11.8:**
+
+        Para actualizar PyTorch y Torchaudio para soportar CUDA 11.8, use los siguientes comandos:
+
+        ```
+        pip install torch==2.3.1+cu118 torchaudio==2.3.1 --index-url https://download.pytorch.org/whl/cu118
+        ```
+
+    - **Para CUDA 12.X:**
+
+        Para actualizar PyTorch y Torchaudio para soportar CUDA 12.X, ejecute lo siguiente:
+
+        ```
+        pip install torch==2.3.1+cu121 torchaudio==2.3.1 --index-url https://download.pytorch.org/whl/cu121
+        ```
+
+    Reemplace `2.3.1` con la versión de PyTorch que coincida con su sistema y requisitos.
+
+5. **Solución para resolver problemas de compatibilidad**:
+    Si encuentra problemas de compatibilidad de bibliotecas, intente establecer estas bibliotecas en versiones fijas:
+
+    ```
+    pip install networkx==2.8.8
+    pip install typing_extensions==4.8.0
+    pip install fsspec==2023.6.0
+    pip install imageio==2.31.6
+    pip install networkx==2.8.8
+    pip install numpy==1.24.3
+    pip install requests==2.31.0
+    ```

--- a/docs/es/usage.md
+++ b/docs/es/usage.md
@@ -1,0 +1,145 @@
+# Uso
+
+## Inicio Rápido
+
+Aquí hay un ejemplo básico de uso:
+
+```python
+from RealtimeTTS import TextToAudioStream, SystemEngine, AzureEngine, ElevenlabsEngine
+
+engine = SystemEngine() # replace with your TTS engine
+stream = TextToAudioStream(engine)
+stream.feed("Hello world! How are you today?")
+stream.play_async()
+```
+
+## Alimentar Texto
+
+Puede alimentar cadenas individuales:
+
+```python
+stream.feed("Hello, this is a sentence.")
+```
+
+O puede alimentar generadores e iteradores de caracteres para la transmisión en tiempo real:
+
+```python
+def write(prompt: str):
+    for chunk in openai.ChatCompletion.create(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content" : prompt}],
+        stream=True
+    ):
+        if (text_chunk := chunk["choices"][0]["delta"].get("content")) is not None:
+            yield text_chunk
+
+text_stream = write("A three-sentence relaxing speech.")
+
+stream.feed(text_stream)
+```
+
+```python
+char_iterator = iter("Streaming this character by character.")
+stream.feed(char_iterator)
+```
+
+## Reproducción
+
+De forma asíncrona:
+
+```python
+stream.play_async()
+while stream.is_playing():
+    time.sleep(0.1)
+```
+
+De forma síncrona:
+
+```python
+stream.play()
+```
+
+## Prueba de la Biblioteca
+
+El subdirectorio de pruebas contiene un conjunto de scripts para ayudarte a evaluar y comprender las capacidades de la biblioteca RealtimeTTS.
+
+Ten en cuenta que la mayoría de las pruebas aún dependen de la API "antigua" de OpenAI (<1.0.0). El uso de la nueva API de OpenAI se demuestra en openai_1.0_test.py.
+
+- **simple_test.py**
+    - **Descripción**: Una demostración tipo "hola mundo" del uso más simple de la biblioteca.
+
+- **complex_test.py**
+    - **Descripción**: Una demostración completa que muestra la mayoría de las características proporcionadas por la biblioteca.
+
+- **coqui_test.py**
+    - **Descripción**: Prueba del motor local coqui TTS.
+
+- **translator.py**
+    - **Dependencias**: Ejecutar `pip install openai realtimestt`.
+    - **Descripción**: Traducciones en tiempo real a seis idiomas diferentes.
+
+- **openai_voice_interface.py**
+    - **Dependencias**: Ejecutar `pip install openai realtimestt`.
+    - **Descripción**: Interfaz de usuario activada por palabra clave y basada en voz para la API de OpenAI.
+
+- **advanced_talk.py**
+    - **Dependencias**: Ejecutar `pip install openai keyboard realtimestt`.
+    - **Descripción**: Elija el motor TTS y la voz antes de iniciar la conversación con IA.
+
+- **minimalistic_talkbot.py**
+    - **Dependencias**: Ejecutar `pip install openai realtimestt`.
+    - **Descripción**: Un talkbot básico en 20 líneas de código.
+
+- **simple_llm_test.py**
+    - **Dependencias**: Ejecutar `pip install openai`.
+    - **Descripción**: Demostración simple de cómo integrar la biblioteca con modelos de lenguaje grande (LLMs).
+
+- **test_callbacks.py**
+    - **Dependencias**: Ejecutar `pip install openai`.
+    - **Descripción**: Muestra los callbacks y te permite verificar los tiempos de latencia en un entorno de aplicación del mundo real.
+
+## Pausar, Reanudar y Detener
+
+Pausar el flujo de audio:
+
+```python
+stream.pause()
+```
+
+Reanudar un flujo pausado:
+
+```python
+stream.resume()
+```
+
+Detener el flujo inmediatamente:
+
+```python
+stream.stop()
+```
+
+## Requisitos Explicados
+
+- **Versión de Python**:
+  - **Requerido**: Python >= 3.9, < 3.13
+  - **Razón**: La biblioteca depende de la biblioteca GitHub "TTS" de coqui, que requiere versiones de Python en este rango.
+
+- **PyAudio**: para crear un flujo de audio de salida
+
+- **stream2sentence**: para dividir el flujo de texto entrante en oraciones
+
+- **pyttsx3**: Motor de conversión de texto a voz del sistema
+
+- **pydub**: para convertir formatos de fragmentos de audio
+
+- **azure-cognitiveservices-speech**: Motor de conversión de texto a voz de Azure
+
+- **elevenlabs**: Motor de conversión de texto a voz de Elevenlabs
+
+- **coqui-TTS**: Biblioteca de texto a voz XTTS de Coqui para TTS neuronal local de alta calidad
+
+  Agradecimiento especial al [Instituto de Investigación Idiap](https://github.com/idiap) por mantener un [fork de coqui tts](https://github.com/idiap/coqui-ai-TTS).
+
+- **openai**: para interactuar con la API TTS de OpenAI
+
+- **gtts**: Conversión de texto a voz de Google translate

--- a/docs/fr/index.md
+++ b/docs/fr/index.md
@@ -1,6 +1,6 @@
 # RealtimeTTS
 
-[EN](../en/index.md) | [FR](../fr/index.md)
+[EN](../en/index.md) | [FR](../fr/index.md) | [ES](../es/index.md)
 
 *Bibliothèque de synthèse vocale à faible latence et facile à utiliser pour les applications en temps réel*
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,25 +18,34 @@ plugins:
         - locale: fr
           name: Français
           build: true
+        - locale: es
+          name: Español
+          build: true  
 nav:
   - Home: 
     - English: en/index.md
     - Français: fr/index.md
+    - Español: es/index.md  
   - Installation: 
     - English: en/installation.md
     - Français: fr/installation.md
+    - Español: es/installation.md  
   - Usage: 
     - English: en/usage.md
     - Français: fr/usage.md
+    - Español: es/usage.md  
   - API Reference: 
     - English: en/api.md
     - Français: fr/api.md
+    - Español: es/api.md  
   - Contributing: 
     - English: en/contributing.md
     - Français: fr/contributing.md
+    - Español: es/contributing.md  
   - FAQ: 
     - English: en/faq.md
     - Français: fr/faq.md
+    - Español: es/faq.md  
 extra:
   alternate:
     - name: English
@@ -45,3 +54,6 @@ extra:
     - name: Français
       link: /fr/
       lang: fr
+    - name: Español
+      link: /es/
+      lang: es  


### PR DESCRIPTION
Hey @KoljaB, 
Since the project's main goal is to convert text to speech in real time, People from different regions should be able to use it without language barriers.
I've added `spanish` language in the docs so that the documentation is more accessible.
Here are screen shots for your reference:
![Screenshot 2024-10-24 170251](https://github.com/user-attachments/assets/052f53ca-434f-451c-89ec-328c37e5d682)
![Screenshot 2024-10-24 170307](https://github.com/user-attachments/assets/9e39bbed-a06c-481d-8baf-2b32a8c3387a)

Please review it and let me know the changes.