### PR TITLE
Downloads Broken Link fixed in Readme 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RealtimeTTS
 [![PyPI](https://img.shields.io/pypi/v/RealtimeTTS)](https://pypi.org/project/RealtimeTTS/)
-[![Downloads](https://static.pepy.tech/badge/RealtimeTTS)](https://pepy.tech/project/KoljaB/RealtimeTTS)
+[![Downloads](https://static.pepy.tech/badge/RealtimeTTS)](https://www.pepy.tech/projects/realtimetts)
 [![GitHub release](https://img.shields.io/github/release/KoljaB/RealtimeTTS.svg)](https://GitHub.com/KoljaB/RealtimeTTS/releases/)
 [![GitHub commits](https://badgen.net/github/commits/KoljaB/RealtimeTTS)](https://GitHub.com/Naereen/KoljaB/RealtimeTTS/commit/)
 [![GitHub forks](https://img.shields.io/github/forks/KoljaB/RealtimeTTS.svg?style=social&label=Fork&maxAge=2592000)](https://GitHub.com/KoljaB/RealtimeTTS/network/)


### PR DESCRIPTION
In this PR, I have fixed the broken link of Downloads in README.
![image](https://github.com/user-attachments/assets/738775c5-d51a-464c-a602-1fc937bf1b19)
Earlier it took a 404 page, now it redirects to the correct page.

Before-
![image](https://github.com/user-attachments/assets/06505279-756d-4cf5-86ce-8957a84d569e)

After- 
![image](https://github.com/user-attachments/assets/a1f6303e-edfc-45b6-ae61-9e300290e9da)
