### PR TITLE
Adding Links for Russian language in all other language Docs

### DIFF
--- a/docs/ar/index.md
+++ b/docs/ar/index.md
@@ -1,6 +1,6 @@
 # RealtimeTTS
 
-[EN](../en/index.md) | [FR](../fr/index.md) | [ES](../es/index.md) | [DE](../de/index.md) | [IT](../it/index.md) | [ZH](../zh/index.md) | [JA](../ja/index.md)
+[EN](../en/index.md) | [FR](../fr/index.md) | [ES](../es/index.md) | [DE](../de/index.md) | [IT](../it/index.md) | [ZH](../zh/index.md) | [JA](../ja/index.md) | [HI](../hi/index.md) | [KO](../ko/index.md) | [RU](../ru/index.md)
 
 *مكتبة تحويل النص إلى كلام سهلة الاستخدام ومنخفضة الكمون للتطبيقات في الوقت الحقيقي*
 

--- a/docs/de/index.md
+++ b/docs/de/index.md
@@ -1,6 +1,6 @@
 # RealtimeTTS
 
-[EN](../en/index.md) | [FR](../fr/index.md) | [ES](../es/index.md) | [DE](../de/index.md) | [IT](../it/index.md) | [ZH](../zh/index.md) | [JA](../ja/index.md) | [HI](../hi/index.md) | [KO](../ko/index.md)
+[EN](../en/index.md) | [FR](../fr/index.md) | [ES](../es/index.md) | [DE](../de/index.md) | [IT](../it/index.md) | [ZH](../zh/index.md) | [JA](../ja/index.md) | [HI](../hi/index.md) | [KO](../ko/index.md) | [RU](../ru/index.md)
 
 * Einfach zu verwendende Text-to-Speech-Bibliothek mit geringer Latenz für Echtzeitanwendungen*
 

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -1,6 +1,6 @@
 # RealtimeTTS
 
-[EN](../en/index.md) | [FR](../fr/index.md) | [ES](../es/index.md) | [DE](../de/index.md) | [IT](../it/index.md) | [ZH](../zh/index.md) | [JA](../ja/index.md) | [HI](../hi/index.md) | [KO](../ko/index.md)
+[EN](../en/index.md) | [FR](../fr/index.md) | [ES](../es/index.md) | [DE](../de/index.md) | [IT](../it/index.md) | [ZH](../zh/index.md) | [JA](../ja/index.md) | [HI](../hi/index.md) | [KO](../ko/index.md) | [RU](../ru/index.md)
 
 *Easy to use, low-latency text-to-speech library for realtime applications*
 

--- a/docs/es/index.md
+++ b/docs/es/index.md
@@ -1,6 +1,6 @@
 # RealtimeTTS
 
-[EN](../en/index.md) | [FR](../fr/index.md) | [ES](../es/index.md) | [DE](../de/index.md) | [IT](../it/index.md) | [ZH](../zh/index.md) | [JA](../ja/index.md) | [HI](../hi/index.md) | [KO](../ko/index.md)
+[EN](../en/index.md) | [FR](../fr/index.md) | [ES](../es/index.md) | [DE](../de/index.md) | [IT](../it/index.md) | [ZH](../zh/index.md) | [JA](../ja/index.md) | [HI](../hi/index.md) | [KO](../ko/index.md) | [RU](../ru/index.md)
 
 *Biblioteca de conversión de texto en voz fácil de usar y de baja latencia para aplicaciones en tiempo real.
 

--- a/docs/fr/index.md
+++ b/docs/fr/index.md
@@ -1,6 +1,6 @@
 # RealtimeTTS
 
-[EN](../en/index.md) | [FR](../fr/index.md) | [ES](../es/index.md) | [DE](../de/index.md) | [IT](../it/index.md) | [ZH](../zh/index.md) | [JA](../ja/index.md) | [HI](../hi/index.md) | [KO](../ko/index.md)
+[EN](../en/index.md) | [FR](../fr/index.md) | [ES](../es/index.md) | [DE](../de/index.md) | [IT](../it/index.md) | [ZH](../zh/index.md) | [JA](../ja/index.md) | [HI](../hi/index.md) | [KO](../ko/index.md) | [RU](../ru/index.md)
 
 *Bibliothèque de synthèse vocale à faible latence et facile à utiliser pour les applications en temps réel*
 

--- a/docs/hi/index.md
+++ b/docs/hi/index.md
@@ -1,6 +1,6 @@
 # RealtimeTTS
 
-[EN](../en/index.md) | [FR](../fr/index.md) | [ES](../es/index.md) | [DE](../de/index.md) | [IT](../it/index.md) | [ZH](../zh/index.md) | [JA](../ja/index.md) | [HI](../hi/index.md) | [KO](../ko/index.md)
+[EN](../en/index.md) | [FR](../fr/index.md) | [ES](../es/index.md) | [DE](../de/index.md) | [IT](../it/index.md) | [ZH](../zh/index.md) | [JA](../ja/index.md) | [HI](../hi/index.md) | [KO](../ko/index.md) | [RU](../ru/index.md)
 
 *रीयल-टाइम अनुप्रयोगों के लिए उपयोग में आसान, कम-विलंबता वाला टेक्स्ट-टू-स्पीच लाइब्रेरी*
 

--- a/docs/it/index.md
+++ b/docs/it/index.md
@@ -1,6 +1,6 @@
 #RealtimeTTS
 
-[EN](../en/index.md) | [FR](../fr/index.md) | [ES](../es/index.md) | [DE](../de/index.md) | [IT](../it/index.md) | [ZH](../zh/index.md) | [JA](../ja/index.md) | [HI](../hi/index.md) | [KO](../ko/index.md)
+[EN](../en/index.md) | [FR](../fr/index.md) | [ES](../es/index.md) | [DE](../de/index.md) | [IT](../it/index.md) | [ZH](../zh/index.md) | [JA](../ja/index.md) | [HI](../hi/index.md) | [KO](../ko/index.md) | [RU](../ru/index.md)
 
 *Libreria text-to-speech facile da usare e a bassa latenza per applicazioni in tempo reale*
 

--- a/docs/ja/index.md
+++ b/docs/ja/index.md
@@ -1,6 +1,6 @@
 # リアルタイムTTS
 
-[EN](../en/index.md) | [FR](../fr/index.md) | [ES](../es/index.md) | [DE](../de/index.md) | [IT](../it/index.md) | [ZH](../zh/index.md) | [JA](../ja/index.md) | [HI](../hi/index.md) | [KO](../ko/index.md)
+[EN](../en/index.md) | [FR](../fr/index.md) | [ES](../es/index.md) | [DE](../de/index.md) | [IT](../it/index.md) | [ZH](../zh/index.md) | [JA](../ja/index.md) | [HI](../hi/index.md) | [KO](../ko/index.md) | [RU](../ru/index.md)
 
 *リアルタイムアプリケーション向けの使いやすく、低遅延のテキスト読み上げライブラリ*
 

--- a/docs/ko/index.md
+++ b/docs/ko/index.md
@@ -1,6 +1,6 @@
 # 실시간TTS
 
-[EN](../en/index.md) | [FR](../fr/index.md) | [ES](../es/index.md) | [DE](../de/index.md) | [IT](../it/index.md) | [ZH](../zh/index.md) | [JA](../ja/index.md) | [HI](../hi/index.md) | [KO](../ko/index.md)
+[EN](../en/index.md) | [FR](../fr/index.md) | [ES](../es/index.md) | [DE](../de/index.md) | [IT](../it/index.md) | [ZH](../zh/index.md) | [JA](../ja/index.md) | [HI](../hi/index.md) | [KO](../ko/index.md) | [RU](../ru/index.md)
 
 *실시간 애플리케이션을 위한 사용하기 쉽고 저지연 텍스트 음성 변환 라이브러리*
 

--- a/docs/pt/index.md
+++ b/docs/pt/index.md
@@ -1,6 +1,6 @@
 # RealtimeTTS
 
-[PT](../pt/index.md) | [FR](../fr/index.md) | [ES](../es/index.md) | [DE](../de/index.md) | [IT](../it/index.md) | [ZH](../zh/index.md) | [JA](../ja/index.md) | [HI](../hi/index.md) | [KO](../ko/index.md)
+[PT](../pt/index.md) | [FR](../fr/index.md) | [ES](../es/index.md) | [DE](../de/index.md) | [IT](../it/index.md) | [ZH](../zh/index.md) | [JA](../ja/index.md) | [HI](../hi/index.md) | [KO](../ko/index.md) | [RU](../ru/index.md)
 
 *Biblioteca de texto para fala fácil de usar e de baixa latência para aplicações em tempo real*
 

--- a/docs/ru/index.md
+++ b/docs/ru/index.md
@@ -1,6 +1,6 @@
 # RealtimeTTS
 
-[EN](../en/index.md) | [FR](../fr/index.md) | [ES](../es/index.md) | [DE](../de/index.md) | [IT](../it/index.md) | [ZH](../zh/index.md) | [JA](../ja/index.md) | [HI](../hi/index.md) | [KO](../ko/index.md)
+[EN](../en/index.md) | [FR](../fr/index.md) | [ES](../es/index.md) | [DE](../de/index.md) | [IT](../it/index.md) | [ZH](../zh/index.md) | [JA](../ja/index.md) | [HI](../hi/index.md) | [KO](../ko/index.md) | [RU](../ru/index.md)
 
 *Легкая в использовании библиотека синтеза речи с низкой задержкой для приложений в реальном времени*
 


### PR DESCRIPTION
I saw that there was no link for the Russian language in the other language Docs So I Added these.