### PR TITLE
Fix voice instantiation issue in Kokoro engine

### DIFF
--- a/RealtimeTTS/engines/__init__.py
+++ b/RealtimeTTS/engines/__init__.py
@@ -13,7 +13,7 @@ __all__ = [
     "EdgeEngine", "EdgeVoice",
     "StyleTTSEngine", "StyleTTSVoice",
     "PiperEngine", "PiperVoice",
-    "KokoroEngine",
+    "KokoroEngine","KokoroAIVoice",
     "OrpheusEngine", "OrpheusVoice",
 ]
 
@@ -79,8 +79,9 @@ def _load_piper_engine():
     return PiperEngine
 
 def _load_kokoro_engine():
-    from .kokoro_engine import KokoroEngine
+    from .kokoro_engine import KokoroEngine,KokoroAIVoice
     globals()["KokoroEngine"] = KokoroEngine
+    globals()["KokoroAIVoice"] = KokoroAIVoice
     return KokoroEngine
 
 def _load_orpheus_engine():

--- a/RealtimeTTS/engines/kokoro_engine.py
+++ b/RealtimeTTS/engines/kokoro_engine.py
@@ -20,6 +20,17 @@ import re
 # Import the text-to-speech pipeline from the Kokoro package.
 from kokoro import KPipeline
 
+
+
+class KokoroAIVoice:
+    def __init__(self, name):
+        self.name = name
+
+    def __repr__(self):
+        return f"{self.name}"
+
+
+
 class KokoroEngine(BaseEngine):
     """
     A text-to-speech (TTS) engine utilizing the Kokoro pipeline, now with support
@@ -367,14 +378,14 @@ class KokoroEngine(BaseEngine):
         if self.debug:
             print(f"[KokoroEngine] Speed set to: {self.speed}")
 
-    def get_voices(self) -> List[str]:
+        def get_voices(self) -> List[str]:
         """
         Retrieves a list of all supported voice identifiers.
 
         Returns:
             List[str]: A list containing all available voice names.
         """
-        return [
+        Kokoro_AI_Voices= [
             # American English (lang_code='a')
             # Female voices (11)
             "af_heart", "af_alloy", "af_aoede", "af_bella", "af_jessica",
@@ -429,6 +440,7 @@ class KokoroEngine(BaseEngine):
             # Male voices (2)
             "pm_alex", "pm_santa",
         ]
+        return [KokoroAIVoice(v) for v in Kokoro_AI_Voices]
 
     def shutdown(self):
         """

--- a/RealtimeTTS/engines/kokoro_engine.py
+++ b/RealtimeTTS/engines/kokoro_engine.py
@@ -378,7 +378,7 @@ class KokoroEngine(BaseEngine):
         if self.debug:
             print(f"[KokoroEngine] Speed set to: {self.speed}")
 
-        def get_voices(self) -> List[str]:
+    def get_voices(self) -> List[str]:
         """
         Retrieves a list of all supported voice identifiers.
 


### PR DESCRIPTION
Hi,

I noticed that other voice engine implementations like OpenAIVoice and CoquiVoice use dedicated classes with constructors that define attributes such as name for each voice. However, kokoro_engine.py does not follow this pattern .

This inconsistency results in an AttributeError when attempting to access the .name attribute while initializing the engine in the FastAPI application.

```

  File "C:\Users\91639\Desktop\Whisper live\RealtimeTTS\example_fast_api\server.py", line 415, in <module>
    _set_engine(START_ENGINE)
  File "C:\Users\91639\Desktop\Whisper live\RealtimeTTS\example_fast_api\server.py", line 133, in _set_engine
    engines[engine_name].set_voice(voices[engine_name][0].name)
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'name'
```
This pull request introduces a fix by ensuring that Kokoro voices follow the same structure as other engines, which resolves the issue.

I’ve been using the library. I like it so far and wanted to contribute a quick improvement.

Thanks!