### PR TITLE
Add `mpv_audio_device` option for audio playback configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,14 @@ When you initialize the `TextToAudioStream` class, you have various options to c
   - **How It Works**: The system will use the device corresponding to this index for audio playback. If `None`, the system's default audio output device is used.  
   - **Obtaining Device Indices**: Use PyAudio's device query methods to retrieve available indices.
 
+#### `mpv_audio_device` (str) For ElevenlabsEngine and EdgeEngine (MPV playout)
+- **Type**: `str`
+- **Required**: No
+- **Default**: `None`
+- **Description**: The name of the audio device to use for playback.
+  - **How It Works**: The system will use the device corresponding to this name for audio playback. If `None`, the system's default audio output device is used.
+  - **Obtaining Device Names**: Use `mpv --audio-device=help` to get the device names.
+
 #### `tokenizer` (string)
 - **Type**: `str`
 - **Required**: No

--- a/RealtimeTTS/stream_player.py
+++ b/RealtimeTTS/stream_player.py
@@ -44,6 +44,7 @@ class AudioConfiguration:
         channels: int = 1,
         rate: int = 16000,
         output_device_index=None,
+        mpv_audio_device=None,
         muted: bool = False,
         frames_per_buffer: int = pa.paFramesPerBufferUnspecified,
         playout_chunk_size: int = -1,
@@ -54,6 +55,7 @@ class AudioConfiguration:
             channels (int): Number of audio channels, e.g., 1 for mono or 2 for stereo. Defaults to 1 (mono).
             rate (int): Sample rate of the audio stream in Hz. Defaults to 16000.
             output_device_index (int): Index of the audio output device. If None, the default output device is used.
+            mpv_audio_device (str): Name of the audio device to use for mpv playback. If None, the system's default audio output device will be used.
             muted (bool): If True, audio playback is muted. Defaults to False.
             frames_per_buffer (int): Number of frames per buffer for PyAudio. Defaults to pa.paFramesPerBufferUnspecified, letting PyAudio choose.
             playout_chunk_size (int): Size of audio chunks (in bytes) to be played out. Defaults to -1, which determines the chunk size based on frames_per_buffer or a default value.
@@ -63,6 +65,7 @@ class AudioConfiguration:
         self.channels = channels
         self.rate = rate
         self.output_device_index = output_device_index
+        self.mpv_audio_device = mpv_audio_device
         self.muted = muted
         self.frames_per_buffer = frames_per_buffer
         self.playout_chunk_size = playout_chunk_size
@@ -208,6 +211,9 @@ class AudioStream:
                     "--",
                     "fd://0"
                 ]
+
+                if self.config.mpv_audio_device:
+                    mpv_command.insert(1, f"--audio-device={self.config.mpv_audio_device}")
 
                 self.mpv_process = subprocess.Popen(
                     mpv_command,

--- a/RealtimeTTS/text_to_stream.py
+++ b/RealtimeTTS/text_to_stream.py
@@ -43,6 +43,7 @@ class TextToAudioStream:
         on_character=None,
         on_word=None,
         output_device_index=None,
+        mpv_audio_device=None,
         tokenizer: str = "nltk",
         language: str = "en",
         muted: bool = False,
@@ -102,6 +103,13 @@ class TextToAudioStream:
                 This index corresponds to the device indices returned by the
                 PyAudio interface.
 
+            mpv_audio_device (str, optional):
+                The name of the audio device to use for playback.
+                If None, the system's default audio output device will be used.
+                This name corresponds to the device names returned by the
+                MPV interface.
+                Use `mpv --audio-device=help` to get the device names.
+
             tokenizer (str, optional):
                 Specifies the tokenizer used to split input text into sentences
                 or smaller chunks for synthesis. Supported options are:
@@ -148,6 +156,7 @@ class TextToAudioStream:
         self.on_audio_stream_start = on_audio_stream_start
         self.on_audio_stream_stop = on_audio_stream_stop
         self.output_device_index = output_device_index
+        self.mpv_audio_device = mpv_audio_device
         self.on_word_spoken = on_word
         self.output_wavfile = None
         self.chunk_callback = None
@@ -210,6 +219,7 @@ class TextToAudioStream:
             channels,
             rate,
             self.output_device_index,
+            self.mpv_audio_device,
             muted=self.global_muted,
             frames_per_buffer=self.frames_per_buffer,
             playout_chunk_size=self.playout_chunk_size,


### PR DESCRIPTION
- Introduced `mpv_audio_device` parameter in `AudioConfiguration` and `TextToAudioStream` classes to specify the audio device name for MPV playback.
- Updated relevant documentation in README.md to reflect the new parameter and its usage.
- fixed #267 