### PR TITLE
Add missing documentation links (PT and RU)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ The documentation for **RealtimeTTS** is available in the following languages:
 - **[Japanese](https://koljab.github.io/RealtimeTTS/ja/)**
 - **[Hindi](https://koljab.github.io/RealtimeTTS/hi/)**
 - **[Korean](https://koljab.github.io/RealtimeTTS/ko/)**
+- **[Portuguese](https://koljab.github.io/RealtimeTTS/pt/)**
+- **[Russian](https://koljab.github.io/RealtimeTTS/ru/)**
 
 ---
 


### PR DESCRIPTION
Hi! I noticed that the README was missing links to the Portuguese and Russian documentation. I've added them to the documentation section to help users from these regions. Thanks!