### PR TITLE
Fix: AttributeError for numpy.ndarray in omnivoice_engine

### DIFF
--- a/RealtimeTTS/engines/omnivoice_engine.py
+++ b/RealtimeTTS/engines/omnivoice_engine.py
@@ -271,7 +271,10 @@ class OmniVoiceEngine(BaseEngine):
                 generate_end = time.perf_counter()
 
             # The audio tensor shape is typically [1, samples] or [samples]
-            waveform = audio[0].cpu().numpy()
+            if hasattr(audio[0], 'cpu'):
+                waveform = audio[0].cpu().numpy()
+            else:
+                waveform = audio[0]
             if waveform.ndim > 1:
                 waveform = waveform[0]  # Ensure mono
 


### PR DESCRIPTION
When using OmniVoice, the synthesis process crashes with AttributeError: 'numpy.ndarray' object has no attribute 'cpu' because the model already returns a numpy array. I added a simple hasattr check to safely handle both tensors and numpy arrays.