### PR TITLE
Allow passing an OpenAI-compatible API URL to the OpenAIEngine

### DIFF
--- a/RealtimeTTS/engines/openai_engine.py
+++ b/RealtimeTTS/engines/openai_engine.py
@@ -28,7 +28,8 @@ class OpenAIEngine(BaseEngine):
             speed: float = None,
             response_format: str = "mp3",
             timeout: float = None,
-            api_key: str = getenv("OPENAI_API_KEY")
+            api_key: str = getenv("OPENAI_API_KEY"),
+            api_url: str | None = None,
         ):
         """
         Initializes an OpenAI realtime text to speech engine object.
@@ -60,7 +61,7 @@ class OpenAIEngine(BaseEngine):
 
         self.timeout = timeout
 
-        self.client = OpenAI(api_key=api_key)
+        self.client = OpenAI(api_key=api_key, base_url=api_url)
         # Assuming queue is defined elsewhere or should be initialized
         self.queue = None
 


### PR DESCRIPTION
Realised that I also needed the ability to set the OpenAI base URL as well and, well, decided to PR this in.

The OpenAI SDK has a set of resolution rules that I'd rather not replicate here, so I decided to just make it settable to None and pass that in so the SDK can do fallback resolution itself.